### PR TITLE
Bump the until-build setting to 162.*

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -9,7 +9,7 @@
     <depends>com.intellij.modules.vcs</depends>
     <depends>Git4Idea</depends>
 
-    <idea-version since-build="143.0" until-build="145.999999"/>
+    <idea-version since-build="143.0" until-build="162.*"/>
 
     <actions>
         <action id="Gitflow.OpenGitflowPopup" class="gitflow.actions.OpenGitflowPopup"


### PR DESCRIPTION
This changes adds support for IDEA 2016.2 and the corresponding other IDEs in order to resolve #111.