### PR TITLE
include builds up to 163.*

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -10,7 +10,7 @@
     <depends>com.intellij.tasks</depends>
     <depends>Git4Idea</depends>
 
-    <idea-version since-build="162.0" until-build="162.*"/>
+    <idea-version since-build="162.0" until-build="163.*"/>
 
     <actions>
         <action id="Gitflow.OpenGitflowPopup" class="gitflow.actions.OpenGitflowPopup"


### PR DESCRIPTION
so it works in Webstorm 2016.3