### PR TITLE
Added option to always create a commit when finishing a feature

### DIFF
--- a/src/gitflow/GitflowConfigurable.java
+++ b/src/gitflow/GitflowConfigurable.java
@@ -13,11 +13,12 @@ import javax.swing.*;
  * @author Andreas Vogler (Andreas.Vogler@geneon.de)
  * @author Opher Vishnia (opherv@gmail.com)
  */
-
 public class GitflowConfigurable implements Configurable {
+
     public static final String GITFLOW_FEATURE_FETCH_ORIGIN = "Gitflow.featureFetchOrigin";
     public static final String GITFLOW_FEATURE_KEEP_REMOTE = "Gitflow.featureKeepRemote";
     public static final String GITFLOW_FEATURE_KEEP_LOCAL = "Gitflow.featureKeepLocal";
+    public static final String GITFLOW_FEATURE_NO_FF = "Gitflow.featureNoFastForward";
 
     public static final String GITFLOW_RELEASE_FETCH_ORIGIN = "Gitflow.releaseFetchOrigin";
     public static final String GITFLOW_PUSH_ON_FINISH_RELEASE = "Gitflow.pushOnFinishRelease";
@@ -26,7 +27,6 @@ public class GitflowConfigurable implements Configurable {
     public static final String GITFLOW_USE_CUSTOM_TAG_COMMIT_MESSAGE = "Gitflow.useCustomTagCommitMessage";
     public static final String GITFLOW_CUSTOM_TAG_COMMIT_MESSAGE = "Gitflow.customTagCommitMessage";
 
-
     public static final String GITFLOW_HOTFIX_FETCH_ORIGIN = "Gitflow.hotfixFetchOrigin";
     public static final String GITFLOW_DONT_TAG_HOTFIX = "Gitflow.dontTagHotfix";
     public static final String GITFLOW_USE_CUSTOM_HOTFIX_TAG_COMMIT_MESSAGE = "Gitflow.useCustomHotfixTagCommitMessage";
@@ -34,13 +34,11 @@ public class GitflowConfigurable implements Configurable {
 
     public static final String DEFAULT_TAG_COMMIT_MESSAGE ="Tagging version %name%";
     public static final String DEFAULT_TAG_HOTFIX_COMMIT_MESSAGE ="Tagging version %name%";
-    Project project;
 
+    Project project;
     GitflowOptionsForm gitflowOptionsForm;
 
-
-    public GitflowConfigurable(Project project)
-    {
+    public GitflowConfigurable(Project project) {
         this.project = project;
     }
 
@@ -58,6 +56,10 @@ public class GitflowConfigurable implements Configurable {
         return PropertiesComponent.getInstance(project).getBoolean(GitflowConfigurable.GITFLOW_FEATURE_KEEP_LOCAL, false);
     }
 
+    public static boolean featureNoFastForward(Project project) {
+        return PropertiesComponent.getInstance(project).getBoolean(GitflowConfigurable.GITFLOW_FEATURE_NO_FF, false);
+    }
+
     /* release */
 
     public static boolean releaseFetchOrigin(Project project) {
@@ -67,7 +69,6 @@ public class GitflowConfigurable implements Configurable {
     public static boolean pushOnReleaseFinish(Project project) {
         return PropertiesComponent.getInstance(project).getBoolean(GitflowConfigurable.GITFLOW_PUSH_ON_FINISH_RELEASE, false);
     }
-
 
     public static boolean dontTagRelease(Project project) {
         return PropertiesComponent.getInstance(project).getBoolean(GitflowConfigurable.GITFLOW_DONT_TAG_RELEASE, false);
@@ -102,8 +103,8 @@ public class GitflowConfigurable implements Configurable {
         return PropertiesComponent.getInstance(project).getBoolean(GitflowConfigurable.GITFLOW_DONT_TAG_HOTFIX, false);
     }
 
-
     /* finish hotfix custom commit message */
+
     public static boolean useCustomHotfixTagCommitMessage(Project project) {
         return PropertiesComponent.getInstance(project).getBoolean(GitflowConfigurable.GITFLOW_USE_CUSTOM_HOTFIX_TAG_COMMIT_MESSAGE, false);
     }
@@ -116,8 +117,6 @@ public class GitflowConfigurable implements Configurable {
             return GitflowConfigurable.DEFAULT_TAG_HOTFIX_COMMIT_MESSAGE;
         }
     }
-
-
 
     @Override
     public String getDisplayName() {
@@ -140,8 +139,9 @@ public class GitflowConfigurable implements Configurable {
     @Override
     public boolean isModified() {
         return PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_FETCH_ORIGIN, false) != gitflowOptionsForm.isFeatureFetchOrigin() ||
-                PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_KEEP_REMOTE, false) != gitflowOptionsForm.isFeatureKeepRemote() ||
-                PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_KEEP_LOCAL, false) != gitflowOptionsForm.isFeatureKeepLocal() ||
+               PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_KEEP_REMOTE, false) != gitflowOptionsForm.isFeatureKeepRemote() ||
+               PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_KEEP_LOCAL, false) != gitflowOptionsForm.isFeatureKeepLocal() ||
+               PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_NO_FF, false) != gitflowOptionsForm.isFeatureNoFastForward() ||
 
                PropertiesComponent.getInstance(project).getBoolean(GITFLOW_RELEASE_FETCH_ORIGIN, false) != gitflowOptionsForm.isReleaseFetchOrigin() ||
                PropertiesComponent.getInstance(project).getBoolean(GITFLOW_PUSH_ON_FINISH_RELEASE, false) != gitflowOptionsForm.isPushOnFinishRelease() ||
@@ -153,8 +153,7 @@ public class GitflowConfigurable implements Configurable {
                PropertiesComponent.getInstance(project).getBoolean(GITFLOW_PUSH_ON_FINISH_HOTFIX, false) != gitflowOptionsForm.isPushOnFinishHotfix() ||
                PropertiesComponent.getInstance(project).getBoolean(GITFLOW_DONT_TAG_HOTFIX, false) != gitflowOptionsForm.isDontTagHotfix() ||
                PropertiesComponent.getInstance(project).getBoolean(GITFLOW_USE_CUSTOM_HOTFIX_TAG_COMMIT_MESSAGE, false) != gitflowOptionsForm.isUseCustomHotfixComitMessage() ||
-               PropertiesComponent.getInstance(project).getValue(GITFLOW_CUSTOM_HOTFIX_TAG_COMMIT_MESSAGE, DEFAULT_TAG_HOTFIX_COMMIT_MESSAGE).equals(gitflowOptionsForm.getCustomHotfixCommitMessage())==false
-                ;
+               PropertiesComponent.getInstance(project).getValue(GITFLOW_CUSTOM_HOTFIX_TAG_COMMIT_MESSAGE, DEFAULT_TAG_HOTFIX_COMMIT_MESSAGE).equals(gitflowOptionsForm.getCustomHotfixCommitMessage())==false;
     }
 
     @Override
@@ -162,6 +161,7 @@ public class GitflowConfigurable implements Configurable {
         PropertiesComponent.getInstance(project).setValue(GITFLOW_FEATURE_FETCH_ORIGIN, Boolean.toString(gitflowOptionsForm.isFeatureFetchOrigin()));
         PropertiesComponent.getInstance(project).setValue(GITFLOW_FEATURE_KEEP_REMOTE, Boolean.toString(gitflowOptionsForm.isFeatureKeepRemote()));
         PropertiesComponent.getInstance(project).setValue(GITFLOW_FEATURE_KEEP_LOCAL, Boolean.toString(gitflowOptionsForm.isFeatureKeepLocal()));
+        PropertiesComponent.getInstance(project).setValue(GITFLOW_FEATURE_NO_FF, Boolean.toString(gitflowOptionsForm.isFeatureNoFastForward()));
 
         PropertiesComponent.getInstance(project).setValue(GITFLOW_RELEASE_FETCH_ORIGIN, Boolean.toString(gitflowOptionsForm.isReleaseFetchOrigin()));
         PropertiesComponent.getInstance(project).setValue(GITFLOW_PUSH_ON_FINISH_RELEASE, Boolean.toString(gitflowOptionsForm.isPushOnFinishRelease()));
@@ -181,6 +181,7 @@ public class GitflowConfigurable implements Configurable {
         gitflowOptionsForm.setFeatureFetchOrigin(PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_FETCH_ORIGIN, false));
         gitflowOptionsForm.setFeatureKeepRemote(PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_KEEP_REMOTE, false));
         gitflowOptionsForm.setFeatureKeepLocal(PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_KEEP_LOCAL, false));
+        gitflowOptionsForm.setFeatureNoFastForward(PropertiesComponent.getInstance(project).getBoolean(GITFLOW_FEATURE_NO_FF, false));
 
         gitflowOptionsForm.setReleaseFetchOrigin(PropertiesComponent.getInstance(project).getBoolean(GITFLOW_RELEASE_FETCH_ORIGIN, false));
         gitflowOptionsForm.setPushOnFinishRelease(PropertiesComponent.getInstance(project).getBoolean(GITFLOW_PUSH_ON_FINISH_RELEASE, false));
@@ -199,4 +200,5 @@ public class GitflowConfigurable implements Configurable {
     public void disposeUIResources() {
         gitflowOptionsForm = null;
     }
+
 }

--- a/src/gitflow/GitflowImpl.java
+++ b/src/gitflow/GitflowImpl.java
@@ -160,6 +160,10 @@ public class GitflowImpl extends GitImpl implements Gitflow {
             h.addParameters("-F");
         }
 
+        if (GitflowConfigurable.featureNoFastForward(repository.getProject())) {
+            h.addParameters("--no-ff");
+        }
+
         h.addParameters(featureName);
 
         for (GitLineHandlerListener listener : listeners) {

--- a/src/gitflow/ui/GitflowOptionsForm.form
+++ b/src/gitflow/ui/GitflowOptionsForm.form
@@ -129,7 +129,7 @@
           </component>
         </children>
       </grid>
-      <grid id="ee6f8" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="ee6f8" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -153,7 +153,7 @@
           </hspacer>
           <vspacer id="1e7f4">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
           <component id="df59e" class="javax.swing.JCheckBox" binding="featureFetchOrigin">
@@ -178,6 +178,19 @@
           <hspacer id="7eec3">
             <constraints>
               <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <component id="76e5a" class="javax.swing.JCheckBox" binding="featureNoFastForward">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Do not fast-forward when merging, always create commit (--no-ff)"/>
+            </properties>
+          </component>
+          <hspacer id="2bce3">
+            <constraints>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
         </children>

--- a/src/gitflow/ui/GitflowOptionsForm.java
+++ b/src/gitflow/ui/GitflowOptionsForm.java
@@ -9,23 +9,25 @@ import java.awt.event.ItemListener;
  * @author Opher Vishnia (opherv@gmail.com)
  */
 public class GitflowOptionsForm  implements ItemListener {
+
     private JPanel contentPane;
     private JCheckBox releaseFetchOrigin;
-    private JCheckBox featureKeepRemote;
 
+    private JCheckBox featureKeepRemote;
+    private JCheckBox featureKeepLocal;
     private JCheckBox featureFetchOrigin;
+    private JCheckBox featureNoFastForward;
+
     private JCheckBox pushOnFinishRelease;
     private JCheckBox dontTagRelease;
     private JCheckBox useCustomTagCommitMessage;
     private JTextField customTagCommitMessage;
-
 
     private JCheckBox hotfixFetchOrigin;
     private JCheckBox pushOnFinishHotfix;
     private JCheckBox dontTagHotfix;
     private JCheckBox useCustomHotfixCommitMessage;
     private JTextField customHotfixCommitMessage;
-    private JCheckBox featureKeepLocal;
 
     public JPanel getContentPane() {
         dontTagRelease.addItemListener(this);
@@ -87,32 +89,63 @@ public class GitflowOptionsForm  implements ItemListener {
                 }
             }
         }
-
-
     }
 
     // feature getters/setters
 
-    public boolean isFeatureFetchOrigin() { return featureFetchOrigin.isSelected(); }
-    public void setFeatureFetchOrigin(boolean selected) { featureFetchOrigin.setSelected(selected); }
+    public boolean isFeatureFetchOrigin() {
+        return featureFetchOrigin.isSelected();
+    }
 
-    public boolean isFeatureKeepRemote() { return featureKeepRemote.isSelected(); }
-    public void setFeatureKeepRemote(boolean selected) { featureKeepRemote.setSelected(selected); }
+    public void setFeatureFetchOrigin(boolean selected) {
+        featureFetchOrigin.setSelected(selected);
+    }
 
-    public boolean isFeatureKeepLocal() { return featureKeepLocal.isSelected(); }
-    public void setFeatureKeepLocal(boolean selected) { featureKeepLocal.setSelected(selected); }
+    public boolean isFeatureKeepRemote() {
+        return featureKeepRemote.isSelected();
+    }
 
+    public void setFeatureKeepRemote(boolean selected) {
+        featureKeepRemote.setSelected(selected);
+    }
+
+    public boolean isFeatureKeepLocal() {
+        return featureKeepLocal.isSelected();
+    }
+
+    public void setFeatureKeepLocal(boolean selected) {
+        featureKeepLocal.setSelected(selected);
+    }
+
+    public boolean isFeatureNoFastForward() {
+        return featureNoFastForward.isSelected();
+    }
+
+    public void setFeatureNoFastForward(boolean selected) {
+        featureNoFastForward.setSelected(selected);
+    }
 
     // release getters/setters
 
-    public boolean isReleaseFetchOrigin() { return releaseFetchOrigin.isSelected(); }
-    public void setReleaseFetchOrigin(boolean selected) { releaseFetchOrigin.setSelected(selected); }
+    public boolean isReleaseFetchOrigin() {
+        return releaseFetchOrigin.isSelected();
+    }
 
-    public boolean isPushOnFinishRelease() { return pushOnFinishRelease.isSelected(); }
-    public void setPushOnFinishRelease(boolean selected) { pushOnFinishRelease.setSelected(selected); }
+    public void setReleaseFetchOrigin(boolean selected) {
+        releaseFetchOrigin.setSelected(selected);
+    }
 
-    public boolean isDontTagRelease() { return dontTagRelease.isSelected(); }
+    public boolean isPushOnFinishRelease() {
+        return pushOnFinishRelease.isSelected();
+    }
 
+    public void setPushOnFinishRelease(boolean selected) {
+        pushOnFinishRelease.setSelected(selected);
+    }
+
+    public boolean isDontTagRelease() {
+        return dontTagRelease.isSelected();
+    }
 
     /* custom finish release tag commit message */
 
@@ -132,41 +165,52 @@ public class GitflowOptionsForm  implements ItemListener {
         customTagCommitMessage.setText(message);
     }
 
-
     // hotfix getters/setters
 
-    public boolean isHotfixFetchOrigin() { return hotfixFetchOrigin.isSelected(); }
-    public void setHotfixFetchOrigin(boolean selected) { hotfixFetchOrigin.setSelected(selected); }
+    public boolean isHotfixFetchOrigin() {
+        return hotfixFetchOrigin.isSelected();
+    }
 
+    public void setHotfixFetchOrigin(boolean selected) {
+        hotfixFetchOrigin.setSelected(selected);
+    }
 
-    public boolean isPushOnFinishHotfix() { return pushOnFinishHotfix.isSelected(); }
-    public void setPushOnFinishHotfix(boolean selected) { pushOnFinishHotfix.setSelected(selected); }
+    public boolean isPushOnFinishHotfix() {
+        return pushOnFinishHotfix.isSelected();
+    }
 
+    public void setPushOnFinishHotfix(boolean selected) {
+        pushOnFinishHotfix.setSelected(selected);
+    }
 
-    public boolean isDontTagHotfix() { return dontTagHotfix.isSelected(); }
+    public boolean isDontTagHotfix() {
+        return dontTagHotfix.isSelected();
+    }
 
     public void setDontTagRelease(boolean selected) {
         dontTagRelease.setSelected(selected);
     }
 
-    public void setDontTagHotfix(boolean selected) { dontTagHotfix.setSelected(selected); }
-
-
+    public void setDontTagHotfix(boolean selected) {
+        dontTagHotfix.setSelected(selected);
+    }
 
     /* custom finish hotfix commit message */
 
-    public boolean isUseCustomHotfixComitMessage(){
+    public boolean isUseCustomHotfixComitMessage() {
         return useCustomHotfixCommitMessage.isSelected();
     }
 
-    public void setUseCustomHotfixCommitMessage(boolean selected){
+    public void setUseCustomHotfixCommitMessage(boolean selected) {
         useCustomHotfixCommitMessage.setSelected(selected);
     }
 
-    public String getCustomHotfixCommitMessage(){
+    public String getCustomHotfixCommitMessage() {
         return customHotfixCommitMessage.getText();
     }
-    public void setCustomHotfixCommitMessage(String message){
+
+    public void setCustomHotfixCommitMessage(String message) {
         customHotfixCommitMessage.setText(message);
     }
+
 }


### PR DESCRIPTION
For single-commit feature branches, git flow fast-forwards the merge and makes it look like the commit was made directly on develop. I've added an option to disable these fast forward merges, using the parameter -no-ff.