### PR TITLE
Do not use GitVcs from GitHandler as project can be null now

### DIFF
--- a/src/gitflow/GitInitLineHandler.java
+++ b/src/gitflow/GitInitLineHandler.java
@@ -12,16 +12,20 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 
+import git4idea.GitVcs;
 import git4idea.commands.GitCommand;
 import git4idea.commands.GitLineHandler;
 
 
 public class GitInitLineHandler extends GitLineHandler {
+    @NotNull private final GitVcs myVcs;
+
     private BufferedWriter writer;
     GitflowInitOptions _initOptions;
 
     public GitInitLineHandler(GitflowInitOptions initOptions, @NotNull Project project, @NotNull VirtualFile vcsRoot, @NotNull GitCommand command) {
         super(project, vcsRoot, command);
+        myVcs = GitVcs.getInstance(project);
         _initOptions = initOptions;
     }
 


### PR DESCRIPTION
During recent refactoring effort `GitHandler` was reworked so that project can now be `null`.
Going forward implementors should no longer rely on project and project-tied (AbstractVcs) fields from `GitHandler`.