### PR TITLE
Fix performance issues in plugin

### DIFF
--- a/src/main/java/gitflow/GitflowBranchUtil.java
+++ b/src/main/java/gitflow/GitflowBranchUtil.java
@@ -29,6 +29,10 @@ public class GitflowBranchUtil {
     String prefixRelease;
     String prefixHotfix;
     String prefixBugfix;
+    private ArrayList<GitRemoteBranch> remoteBranches;
+    private ArrayList<String> remoteBranchNames;
+    private ArrayList<GitLocalBranch> localBranches;
+    private ArrayList<String> localBranchNames;
 
     public GitflowBranchUtil(Project project, GitRepository repo){
         myProject=project;
@@ -42,6 +46,9 @@ public class GitflowBranchUtil {
             prefixRelease = GitflowConfigUtil.getReleasePrefix(project, repo);
             prefixHotfix = GitflowConfigUtil.getHotfixPrefix(project, repo);
             prefixBugfix = GitflowConfigUtil.getBugfixPrefix(project, repo);
+
+            initRemoteBranches();
+            initLocalBranchNames();
         }
     }
 
@@ -97,9 +104,31 @@ public class GitflowBranchUtil {
         return branchName.startsWith(prefixBugfix);
     }
 
+    private void initRemoteBranches() {
+        remoteBranches =
+                new ArrayList<GitRemoteBranch>(myRepo.getBranches().getRemoteBranches());
+        remoteBranchNames = new ArrayList<String>();
+
+        for(Iterator<GitRemoteBranch> i = remoteBranches.iterator(); i.hasNext(); ) {
+            GitRemoteBranch branch = i.next();
+            remoteBranchNames.add(branch.getName());
+        }
+    }
+
+    private void initLocalBranchNames(){
+        localBranches =
+                new ArrayList<GitLocalBranch>(myRepo.getBranches().getLocalBranches());
+        localBranchNames = new ArrayList<String>();
+
+        for(Iterator<GitLocalBranch> i = localBranches.iterator(); i.hasNext(); ) {
+            GitLocalBranch branch = i.next();
+            localBranchNames.add(branch.getName());
+        }
+    }
+
     //if no prefix specified, returns all remote branches
     public ArrayList<String> getRemoteBranchesWithPrefix(String prefix){
-        ArrayList<String> remoteBranches = getRemoteBranchNames();
+        ArrayList<String> remoteBranches = remoteBranchNames;
         ArrayList<String> selectedBranches = new ArrayList<String>();
 
         for(Iterator<String> i = remoteBranches.iterator(); i.hasNext(); ) {
@@ -127,40 +156,19 @@ public class GitflowBranchUtil {
     }
 
     public ArrayList<String> getRemoteBranchNames(){
-        ArrayList<GitRemoteBranch> remoteBranches = new ArrayList<GitRemoteBranch>(myRepo.getBranches().getRemoteBranches());
-        ArrayList<String> branchNameList = new ArrayList<String>();
-
-        for(Iterator<GitRemoteBranch> i = remoteBranches.iterator(); i.hasNext(); ) {
-            GitRemoteBranch branch = i.next();
-            branchNameList.add(branch.getName());
-        }
-
-        return branchNameList;
+        return remoteBranchNames;
     }
 
-
-    public ArrayList<String> getLocalBranchNames(){
-        ArrayList<GitLocalBranch> localBranches = new ArrayList<GitLocalBranch>(myRepo.getBranches().getLocalBranches());
-        ArrayList<String> branchNameList = new ArrayList<String>();
-
-        for(Iterator<GitLocalBranch> i = localBranches.iterator(); i.hasNext(); ) {
-            GitLocalBranch branch = i.next();
-            branchNameList.add(branch.getName());
-        }
-
-        return branchNameList;
+    public ArrayList<String> getLocalBranchNames() {
+        return localBranchNames;
     }
-
-
 
     public GitRemote getRemoteByBranch(String branchName){
         GitRemote remote=null;
 
-        ArrayList<GitRemoteBranch> remoteBranches= new ArrayList<GitRemoteBranch>(myRepo.getBranches().getRemoteBranches());
-
         for(Iterator<GitRemoteBranch> i = remoteBranches.iterator(); i.hasNext(); ) {
             GitRemoteBranch branch = i.next();
-            if (branch.getName()==branchName){
+            if (branch.getName().equals(branchName)){
                 remote=branch.getRemote();
                 break;
             }

--- a/src/main/java/gitflow/GitflowBranchUtil.java
+++ b/src/main/java/gitflow/GitflowBranchUtil.java
@@ -23,12 +23,13 @@ public class GitflowBranchUtil {
     Project myProject;
     GitRepository myRepo;
 
-    String currentBranchName;
-    String branchnameMaster;
-    String prefixFeature;
-    String prefixRelease;
-    String prefixHotfix;
-    String prefixBugfix;
+    private String currentBranchName;
+    private String branchnameMaster;
+    private String branchnameDevelop;
+    private String prefixFeature;
+    private String prefixRelease;
+    private String prefixHotfix;
+    private String prefixBugfix;
     private ArrayList<GitRemoteBranch> remoteBranches;
     private ArrayList<String> remoteBranchNames;
     private ArrayList<GitLocalBranch> localBranches;
@@ -42,6 +43,7 @@ public class GitflowBranchUtil {
             currentBranchName = GitBranchUtil.getBranchNameOrRev(repo);
 
             branchnameMaster= GitflowConfigUtil.getMasterBranch(project, repo);
+            branchnameDevelop = GitflowConfigUtil.getDevelopBranch(project, repo);
             prefixFeature = GitflowConfigUtil.getFeaturePrefix(project, repo);
             prefixRelease = GitflowConfigUtil.getReleasePrefix(project, repo);
             prefixHotfix = GitflowConfigUtil.getHotfixPrefix(project, repo);
@@ -52,16 +54,18 @@ public class GitflowBranchUtil {
         }
     }
 
-    public boolean hasGitflow(){
-        boolean hasGitflow=false;
+    public String getCurrentBranchName() {
+        return currentBranchName;
+    }
 
-        hasGitflow = myRepo != null
-                       && GitflowConfigUtil.getMasterBranch(myProject, myRepo)!=null
-                       && GitflowConfigUtil.getDevelopBranch(myProject, myRepo)!=null
-                       && GitflowConfigUtil.getFeaturePrefix(myProject, myRepo)!=null
-                       && GitflowConfigUtil.getReleasePrefix(myProject, myRepo)!=null
-                       && GitflowConfigUtil.getHotfixPrefix(myProject, myRepo)!=null
-                       && GitflowConfigUtil.getBugfixPrefix(myProject, myRepo)!=null;
+    public boolean hasGitflow(){
+        boolean hasGitflow = myRepo != null
+                       && branchnameMaster != null
+                       && branchnameDevelop != null
+                       && prefixFeature != null
+                       && prefixRelease != null
+                       && prefixHotfix != null
+                       && prefixBugfix != null;
 
         return hasGitflow;
     }

--- a/src/main/java/gitflow/GitflowBranchUtil.java
+++ b/src/main/java/gitflow/GitflowBranchUtil.java
@@ -70,6 +70,30 @@ public class GitflowBranchUtil {
         return hasGitflow;
     }
 
+    public String getBranchnameMaster() {
+        return branchnameMaster;
+    }
+
+    public String getBranchnameDevelop() {
+        return branchnameDevelop;
+    }
+
+    public String getPrefixFeature() {
+        return prefixFeature;
+    }
+
+    public String getPrefixRelease() {
+        return prefixRelease;
+    }
+
+    public String getPrefixHotfix() {
+        return prefixHotfix;
+    }
+
+    public String getPrefixBugfix() {
+        return prefixBugfix;
+    }
+
     public boolean isCurrentBranchMaster(){
         return currentBranchName.startsWith(branchnameMaster);
     }

--- a/src/main/java/gitflow/actions/AbstractBranchAction.java
+++ b/src/main/java/gitflow/actions/AbstractBranchAction.java
@@ -1,0 +1,60 @@
+package gitflow.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import git4idea.repo.GitRepository;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractBranchAction extends GitflowAction {
+    enum BranchType {
+        Feature, Release, Bugfix, Hotfix
+    }
+
+    BranchType type;
+
+    AbstractBranchAction(String actionName, BranchType type) {
+        super(actionName);
+        this.type = type;
+    }
+
+    AbstractBranchAction(GitRepository repo, String actionName, BranchType type) {
+        super(repo, actionName);
+        this.type = type;
+    }
+
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        if (branchUtil == null) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        //Disable and hide when gitflow has not been setup
+        if (branchUtil.hasGitflow() == false) {
+            e.getPresentation().setEnabledAndVisible(false);
+            return;
+        }
+
+        //Disable and hide when the branch-type is incorrect
+        if (isActionAllowedForBranch() == false) {
+            e.getPresentation().setEnabledAndVisible(false);
+        } else {
+            e.getPresentation().setEnabledAndVisible(true);
+        }
+    }
+
+    protected boolean isActionAllowedForBranch() {
+        switch (type) {
+            case Feature:
+                return branchUtil.isCurrentBranchFeature();
+            case Release:
+                return branchUtil.isCurrentBranchRelease();
+            case Bugfix:
+                return branchUtil.isCurrentBranchBugfix();
+            case Hotfix:
+                return branchUtil.isCurrentBranchHotfix();
+            default:
+                return false;
+        }
+    }
+}

--- a/src/main/java/gitflow/actions/AbstractPublishAction.java
+++ b/src/main/java/gitflow/actions/AbstractPublishAction.java
@@ -1,0 +1,22 @@
+package gitflow.actions;
+
+import git4idea.repo.GitRepository;
+
+public abstract class AbstractPublishAction extends AbstractBranchAction {
+    AbstractPublishAction(String actionName, BranchType type) {
+        super(actionName, type);
+    }
+
+    AbstractPublishAction(GitRepository repo, String actionName, BranchType type) {
+        super(repo, actionName, type);
+    }
+
+    @Override
+    protected boolean isActionAllowedForBranch() {
+        if (!super.isActionAllowedForBranch()) {
+            return false;
+        }
+        
+        return !branchUtil.isCurrentBranchPublished();
+    }
+}

--- a/src/main/java/gitflow/actions/AbstractStartAction.java
+++ b/src/main/java/gitflow/actions/AbstractStartAction.java
@@ -1,0 +1,30 @@
+package gitflow.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import git4idea.repo.GitRepository;
+import gitflow.GitflowBranchUtil;
+import gitflow.GitflowBranchUtilManager;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractStartAction extends GitflowAction {
+    AbstractStartAction(String actionName) {
+        super(actionName);
+    }
+
+    AbstractStartAction(GitRepository repo, String actionName) {
+        super(repo, actionName);
+    }
+
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        GitflowBranchUtil branchUtil = GitflowBranchUtilManager.getBranchUtil(myRepo);
+
+        //Disable and hide when gitflow has not been setup
+        if (branchUtil.hasGitflow() == false) {
+            e.getPresentation().setEnabledAndVisible(false);
+        } else {
+            e.getPresentation().setEnabledAndVisible(true);
+        }
+    }
+}

--- a/src/main/java/gitflow/actions/AbstractTrackAction.java
+++ b/src/main/java/gitflow/actions/AbstractTrackAction.java
@@ -1,0 +1,36 @@
+package gitflow.actions;
+
+import git4idea.repo.GitRepository;
+
+public abstract class AbstractTrackAction extends AbstractBranchAction {
+    AbstractTrackAction(String actionName, BranchType type) {
+        super(actionName, type);
+    }
+
+    AbstractTrackAction(GitRepository repo, String actionName, BranchType type) {
+        super(repo, actionName, type);
+    }
+
+    @Override
+    protected boolean isActionAllowedForBranch() {
+        String prefix;
+        switch (type) {
+            case Feature:
+                prefix = featurePrefix;
+                break;
+            case Release:
+                prefix = releasePrefix;
+                break;
+            case Bugfix:
+                prefix = bugfixPrefix;
+                break;
+            default:
+                return false;
+        }
+
+        boolean noRemoteBranches = branchUtil.getRemoteBranchesWithPrefix(prefix).isEmpty();
+        boolean trackedAllBranches = branchUtil.areAllBranchesTracked(prefix);
+
+        return noRemoteBranches == false && trackedAllBranches == false;
+    }
+}

--- a/src/main/java/gitflow/actions/FinishBugfixAction.java
+++ b/src/main/java/gitflow/actions/FinishBugfixAction.java
@@ -11,20 +11,20 @@ import gitflow.GitflowConfigUtil;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class FinishBugfixAction extends GitflowAction {
+public class FinishBugfixAction extends AbstractBranchAction {
 
     String customBugfixName =null;
 
     public FinishBugfixAction() {
-        super("Finish Bugfix");
+        super("Finish Bugfix", BranchType.Bugfix);
     }
 
     public FinishBugfixAction(GitRepository repo) {
-        super(repo, "Finish Bugfix");
+        super(repo, "Finish Bugfix", BranchType.Bugfix);
     }
 
     FinishBugfixAction(GitRepository repo, String name) {
-        super(repo, "Finish Bugfix");
+        super(repo, "Finish Bugfix", BranchType.Bugfix);
         customBugfixName =name;
     }
 

--- a/src/main/java/gitflow/actions/FinishFeatureAction.java
+++ b/src/main/java/gitflow/actions/FinishFeatureAction.java
@@ -11,20 +11,20 @@ import gitflow.GitflowConfigUtil;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class FinishFeatureAction extends GitflowAction {
+public class FinishFeatureAction extends AbstractBranchAction {
 
     String customFeatureName=null;
 
     public FinishFeatureAction() {
-        super("Finish Feature");
+        super("Finish Feature", BranchType.Feature);
     }
 
     public FinishFeatureAction(GitRepository repo) {
-        super(repo, "Finish Feature");
+        super(repo, "Finish Feature", BranchType.Feature);
     }
 
     FinishFeatureAction(GitRepository repo, String name) {
-        super(repo, "Finish Feature");
+        super(repo, "Finish Feature", BranchType.Feature);
         customFeatureName=name;
     }
 

--- a/src/main/java/gitflow/actions/FinishHotfixAction.java
+++ b/src/main/java/gitflow/actions/FinishHotfixAction.java
@@ -13,13 +13,13 @@ import gitflow.GitflowConfigurable;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class FinishHotfixAction extends GitflowAction {
+public class FinishHotfixAction extends AbstractBranchAction {
 
     public FinishHotfixAction() {
-        super("Finish Hotfix");
+        super("Finish Hotfix", BranchType.Hotfix);
     }
     public FinishHotfixAction(GitRepository repo) {
-        super(repo, "Finish Hotfix");
+        super(repo, "Finish Hotfix", BranchType.Hotfix);
     }
 
     @Override

--- a/src/main/java/gitflow/actions/FinishReleaseAction.java
+++ b/src/main/java/gitflow/actions/FinishReleaseAction.java
@@ -12,21 +12,21 @@ import gitflow.GitflowConfigurable;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class FinishReleaseAction extends GitflowAction {
+public class FinishReleaseAction extends AbstractBranchAction {
 
 	String customReleaseName=null;
 	String customtagMessage=null;
 
     FinishReleaseAction() {
-        super("Finish Release");
+        super("Finish Release", AbstractBranchAction.BranchType.Release);
     }
 
     FinishReleaseAction(GitRepository repo) {
-        super(repo, "Finish Release");
+        super(repo, "Finish Release", BranchType.Release);
     }
 
 	FinishReleaseAction(String name, String tagMessage) {
-		super("Finish Release");
+		super("Finish Release", BranchType.Release);
 		customReleaseName = name;
 		customtagMessage = tagMessage;
 	}

--- a/src/main/java/gitflow/actions/GitflowAction.java
+++ b/src/main/java/gitflow/actions/GitflowAction.java
@@ -13,7 +13,6 @@ import git4idea.repo.GitRepository;
 import gitflow.Gitflow;
 import gitflow.GitflowBranchUtil;
 import gitflow.GitflowBranchUtilManager;
-import gitflow.GitflowConfigUtil;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,6 +42,9 @@ public class GitflowAction extends DumbAwareAction {
     GitflowAction(GitRepository repo, String actionName){
         super(actionName);
         myRepo = repo;
+
+        branchUtil = GitflowBranchUtilManager.getBranchUtil(myRepo);
+        setupPrefixes();
     }
 
     @Override
@@ -56,21 +58,25 @@ public class GitflowAction extends DumbAwareAction {
         setup(project);
     }
 
-    public void setup(Project project){
+    private void setup(Project project){
         myProject = project;
         virtualFileMananger = VirtualFileManager.getInstance();
         repos.add(myRepo);
 
-        featurePrefix = GitflowConfigUtil.getFeaturePrefix(myProject, myRepo);
-        releasePrefix = GitflowConfigUtil.getReleasePrefix(myProject, myRepo);
-        hotfixPrefix= GitflowConfigUtil.getHotfixPrefix(myProject, myRepo);
-        bugfixPrefix = GitflowConfigUtil.getBugfixPrefix(myProject, myRepo);
-        masterBranch= GitflowConfigUtil.getMasterBranch(myProject, myRepo);
-        developBranch= GitflowConfigUtil.getDevelopBranch(myProject, myRepo);
-
         branchUtil= GitflowBranchUtilManager.getBranchUtil(myRepo);
 
-        currentBranchName= GitBranchUtil.getBranchNameOrRev(myRepo);
+        setupPrefixes();
+    }
+
+    private void setupPrefixes() {
+        featurePrefix = branchUtil.getPrefixFeature();
+        releasePrefix = branchUtil.getPrefixRelease();
+        hotfixPrefix = branchUtil.getPrefixHotfix();
+        bugfixPrefix = branchUtil.getPrefixBugfix();
+        masterBranch = branchUtil.getBranchnameMaster();
+        developBranch = branchUtil.getBranchnameDevelop();
+
+        currentBranchName = branchUtil.getCurrentBranchName();
     }
 
     public void runAction(Project project, final String baseBranchName, final String branchName, @Nullable final Runnable callInAwtLater){

--- a/src/main/java/gitflow/actions/InitRepoAction.java
+++ b/src/main/java/gitflow/actions/InitRepoAction.java
@@ -6,6 +6,8 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.util.Key;
 import git4idea.commands.GitCommandResult;
 import git4idea.repo.GitRepository;
+import gitflow.GitflowBranchUtil;
+import gitflow.GitflowBranchUtilManager;
 import gitflow.GitflowInitOptions;
 import gitflow.ui.GitflowInitOptionsDialog;
 import gitflow.ui.NotifyUtil;
@@ -19,6 +21,18 @@ public class InitRepoAction extends GitflowAction {
 
     InitRepoAction(GitRepository repo) {
         super(repo,"Init Repo");
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        GitflowBranchUtil branchUtil = GitflowBranchUtilManager.getBranchUtil(myRepo);
+
+        //Disable and hide when gitflow has not been setup
+        if (branchUtil.hasGitflow()) {
+            e.getPresentation().setEnabledAndVisible(false);
+        } else {
+            e.getPresentation().setEnabledAndVisible(true);
+        }
     }
 
     @Override

--- a/src/main/java/gitflow/actions/PublishBugfixAction.java
+++ b/src/main/java/gitflow/actions/PublishBugfixAction.java
@@ -9,11 +9,15 @@ import gitflow.GitflowConfigUtil;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class PublishBugfixAction extends GitflowAction {
+public class PublishBugfixAction extends AbstractPublishAction {
 
-    PublishBugfixAction(){ super("Publish Bugfix");}
+    PublishBugfixAction(){
+        super("Publish Bugfix", BranchType.Bugfix);
+    }
 
-    PublishBugfixAction(GitRepository repo){ super(repo,"Publish Bugfix");}
+    PublishBugfixAction(GitRepository repo){
+        super(repo, "Publish Bugfix", BranchType.Bugfix);
+    }
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {

--- a/src/main/java/gitflow/actions/PublishFeatureAction.java
+++ b/src/main/java/gitflow/actions/PublishFeatureAction.java
@@ -9,10 +9,14 @@ import gitflow.GitflowConfigUtil;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class PublishFeatureAction extends GitflowAction {
-    PublishFeatureAction(){ super("Publish Feature");}
+public class PublishFeatureAction extends AbstractPublishAction {
+    PublishFeatureAction(){
+        super("Publish Feature", BranchType.Feature);
+    }
 
-    PublishFeatureAction(GitRepository repo){ super(repo,"Publish Feature");}
+    PublishFeatureAction(GitRepository repo){
+        super(repo, "Publish Feature", BranchType.Feature);
+    }
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {

--- a/src/main/java/gitflow/actions/PublishHotfixAction.java
+++ b/src/main/java/gitflow/actions/PublishHotfixAction.java
@@ -10,13 +10,13 @@ import gitflow.GitflowConfigUtil;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class PublishHotfixAction extends GitflowAction {
+public class PublishHotfixAction extends AbstractPublishAction {
     PublishHotfixAction() {
-        super("Publish Hotfix");
+        super("Publish Hotfix", BranchType.Hotfix);
     }
 
     PublishHotfixAction(GitRepository repo) {
-        super(repo, "Publish Hotfix");
+        super(repo, "Publish Hotfix", BranchType.Hotfix);
     }
 
     @Override

--- a/src/main/java/gitflow/actions/PublishReleaseAction.java
+++ b/src/main/java/gitflow/actions/PublishReleaseAction.java
@@ -9,14 +9,14 @@ import gitflow.GitflowConfigUtil;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class PublishReleaseAction extends GitflowAction {
+public class PublishReleaseAction extends AbstractPublishAction {
 
     PublishReleaseAction(){
-        super("Publish Release");
+        super("Publish Release", BranchType.Release);
     }
 
     PublishReleaseAction(GitRepository repo){
-        super(repo,"Publish Release");
+        super(repo,"Publish Release", BranchType.Release);
     }
 
     @Override

--- a/src/main/java/gitflow/actions/RepoActions.java
+++ b/src/main/java/gitflow/actions/RepoActions.java
@@ -11,9 +11,6 @@ import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.project.Project;
 import git4idea.branch.GitBranchUtil;
 import git4idea.repo.GitRepository;
-import gitflow.GitflowBranchUtil;
-import gitflow.GitflowBranchUtilManager;
-import gitflow.GitflowConfigUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,6 +20,7 @@ import java.util.Iterator;
 class RepoActions extends BranchActionGroup implements PopupElementWithAdditionalInfo, FileEditorManagerListener {
     Project myProject;
     GitRepository myRepo;
+    private final ArrayList<AnAction> repoActions;
 
     RepoActions(@NotNull Project project, @NotNull GitRepository repo) {
         myProject = project;
@@ -32,122 +30,41 @@ class RepoActions extends BranchActionGroup implements PopupElementWithAdditiona
         getTemplatePresentation().setText(repoName, false); // no mnemonics
         this.updateFavoriteIcon();
         project.getMessageBus().connect().subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, this);
+
+        repoActions = getRepoActions();
     }
 
     public ArrayList<AnAction> getRepoActions(){
         ArrayList<AnAction> actionList = new ArrayList<AnAction>();
 
-        GitflowBranchUtil branchUtil = GitflowBranchUtilManager.getBranchUtil(myRepo);
+        actionList.add(new InitRepoAction(myRepo));
 
+        //FEATURE ACTIONS
+        actionList.add(new Separator("Feature"));
+        actionList.add(new StartFeatureAction(myRepo));
+        actionList.add(new FinishFeatureAction(myRepo));
+        actionList.add(new PublishFeatureAction(myRepo));
+        actionList.add(new TrackFeatureAction(myRepo));
 
-        boolean noRemoteTrackBranches = false;
-        boolean noRemoteFeatureBranches = false;
-        boolean noRemoteBugfixBranches = false;
+        //RELEASE ACTIONS
+        actionList.add(new Separator("Release"));
+        actionList.add(new StartReleaseAction(myRepo));
+        actionList.add(new FinishReleaseAction(myRepo));
+        actionList.add(new PublishReleaseAction(myRepo));
+        actionList.add(new TrackReleaseAction(myRepo));
 
-        boolean trackedAllFeatureBranches = false;
-        boolean trackedAllReleaseBranches = false;
-        boolean trackedAllBugfixBranches = false;
+        //BUGFIX ACTIONS
+        actionList.add(new Separator("Bugfix"));
+        actionList.add(new StartBugfixAction(myRepo));
+        actionList.add(new FinishBugfixAction(myRepo));
+        actionList.add(new PublishBugfixAction(myRepo));
+        actionList.add(new TrackBugfixAction(myRepo));
 
-        String currentBranchName = GitBranchUtil.getBranchNameOrRev(myRepo);
-
-        String featurePrefix = GitflowConfigUtil.getFeaturePrefix(myProject, myRepo);
-        String releasePrefix = GitflowConfigUtil.getReleasePrefix(myProject, myRepo);
-        String hotfixPrefix= GitflowConfigUtil.getHotfixPrefix(myProject, myRepo);
-        String masterBranch= GitflowConfigUtil.getMasterBranch(myProject, myRepo);
-        String developBranch= GitflowConfigUtil.getDevelopBranch(myProject, myRepo);
-        String bugfixPrefix = GitflowConfigUtil.getBugfixPrefix(myProject, myRepo);
-
-        if (releasePrefix!=null){
-            noRemoteTrackBranches = branchUtil.getRemoteBranchesWithPrefix(releasePrefix).isEmpty();
-            trackedAllReleaseBranches = branchUtil.areAllBranchesTracked(releasePrefix);
-        }
-        if (featurePrefix!=null){
-            noRemoteFeatureBranches = branchUtil.getRemoteBranchesWithPrefix(featurePrefix).isEmpty();
-            trackedAllFeatureBranches = branchUtil.areAllBranchesTracked(featurePrefix);
-        }
-        if (bugfixPrefix!=null){
-            noRemoteBugfixBranches = branchUtil.getRemoteBranchesWithPrefix(bugfixPrefix).isEmpty();
-            trackedAllBugfixBranches = branchUtil.areAllBranchesTracked(bugfixPrefix);
-        }
-
-        //gitflow not setup
-        if (branchUtil.hasGitflow()!=true){
-            actionList.add(new InitRepoAction(myRepo));
-        }
-        else{
-
-            //FEATURE ACTIONS
-
-            actionList.add(new Separator("Feature"));
-            actionList.add(new StartFeatureAction(myRepo));
-            //feature only actions
-            if (branchUtil.isCurrentBranchFeature()){
-                actionList.add(new FinishFeatureAction(myRepo));
-
-                //can't publish feature if it's already published
-                if (branchUtil.isCurrentBranchPublished()==false){
-                    actionList.add(new PublishFeatureAction(myRepo));
-                }
-            }
-
-            //make sure there's a feature to track, and that not all features are tracked
-            if (noRemoteFeatureBranches == false && trackedAllFeatureBranches == false){
-                actionList.add(new TrackFeatureAction(myRepo));
-            }
-
-
-            //RELEASE ACTIONS
-
-            actionList.add(new Separator("Release"));
-            actionList.add(new StartReleaseAction(myRepo));
-            //release only actions
-            if (branchUtil.isCurrentBranchRelease()){
-                actionList.add(new FinishReleaseAction(myRepo));
-
-                //can't publish release if it's already published
-                if (branchUtil.isCurrentBranchPublished()==false){
-                    actionList.add(new PublishReleaseAction(myRepo));
-                }
-            }
-
-            //make sure there's something to track and that not all features are tracked
-            if (noRemoteTrackBranches==false  && trackedAllReleaseBranches ==false){
-                actionList.add(new TrackReleaseAction(myRepo));
-            }
-
-
-            //BUGFIX ACTIONS
-
-            actionList.add(new Separator("Bugfix"));
-            actionList.add(new StartBugfixAction(myRepo));
-            //bugfix only actions
-            if (branchUtil.isCurrentBranchBugfix()){
-                actionList.add(new FinishBugfixAction(myRepo));
-
-                //can't publish bugfix if it's already published
-                if (branchUtil.isCurrentBranchPublished()==false){
-                    actionList.add(new PublishBugfixAction(myRepo));
-                }
-            }
-
-            //make sure there's a bugfix to track, and that not all bugfixes are tracked
-            if (noRemoteBugfixBranches == false && trackedAllBugfixBranches == false){
-                actionList.add(new TrackBugfixAction(myRepo));
-            }
-
-            //HOTFIX ACTIONS
-            actionList.add(new Separator("Hotfix"));
-
-            //master only actions
-            actionList.add(new StartHotfixAction(myRepo));
-            if (branchUtil.isCurrentBranchHotfix()){
-                actionList.add(new FinishHotfixAction(myRepo));
-
-                //can't publish hotfix if it's already published
-                if (branchUtil.isCurrentBranchPublished() == false) {
-                    actionList.add(new PublishHotfixAction(myRepo));
-                }
-            }
+        //HOTFIX ACTIONS
+        actionList.add(new Separator("Hotfix"));
+        actionList.add(new StartHotfixAction(myRepo));
+        actionList.add(new FinishHotfixAction(myRepo));
+        actionList.add(new PublishHotfixAction(myRepo));
 
         }
 
@@ -169,8 +86,9 @@ class RepoActions extends BranchActionGroup implements PopupElementWithAdditiona
     @NotNull
     @Override
     public AnAction[] getChildren(@Nullable AnActionEvent e) {
-        ArrayList<AnAction> children = this.getRepoActions();
-        return children.toArray(new AnAction[children.size()]);
+        ArrayList<AnAction> children = new ArrayList<AnAction>(this.repoActions);
+
+        return children.toArray(new AnAction[0]);
     }
 
     @Override

--- a/src/main/java/gitflow/actions/StartBugfixAction.java
+++ b/src/main/java/gitflow/actions/StartBugfixAction.java
@@ -12,7 +12,7 @@ import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class StartBugfixAction extends GitflowAction {
+public class StartBugfixAction extends AbstractStartAction {
 
     public StartBugfixAction() {
         super("Start Bugfix");

--- a/src/main/java/gitflow/actions/StartFeatureAction.java
+++ b/src/main/java/gitflow/actions/StartFeatureAction.java
@@ -5,17 +5,14 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
-
-import git4idea.repo.GitRepository;
-import org.jetbrains.annotations.NotNull;
-
 import git4idea.commands.GitCommandResult;
+import git4idea.repo.GitRepository;
 import gitflow.ui.GitflowStartFeatureDialog;
 import gitflow.ui.NotifyUtil;
-
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class StartFeatureAction extends GitflowAction {
+public class StartFeatureAction extends AbstractStartAction {
 
     public StartFeatureAction() {
         super("Start Feature");

--- a/src/main/java/gitflow/actions/StartHotfixAction.java
+++ b/src/main/java/gitflow/actions/StartHotfixAction.java
@@ -5,18 +5,15 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
-
-import git4idea.repo.GitRepository;
-import org.jetbrains.annotations.NotNull;
-
 import git4idea.commands.GitCommandResult;
+import git4idea.repo.GitRepository;
 import gitflow.ui.GitflowStartHotfixDialog;
 import gitflow.ui.NotifyUtil;
-
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 
-public class StartHotfixAction extends GitflowAction {
+public class StartHotfixAction extends AbstractStartAction {
 
     public StartHotfixAction(GitRepository repo) {
         super(repo, "Start Hotfix");

--- a/src/main/java/gitflow/actions/StartReleaseAction.java
+++ b/src/main/java/gitflow/actions/StartReleaseAction.java
@@ -10,7 +10,7 @@ import git4idea.validators.GitNewBranchNameValidator;
 import gitflow.ui.NotifyUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class StartReleaseAction extends GitflowAction {
+public class StartReleaseAction extends AbstractStartAction {
 
     StartReleaseAction() {
         super("Start Release");

--- a/src/main/java/gitflow/actions/TrackBugfixAction.java
+++ b/src/main/java/gitflow/actions/TrackBugfixAction.java
@@ -14,14 +14,14 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-public class TrackBugfixAction extends GitflowAction {
+public class TrackBugfixAction extends AbstractTrackAction {
 
     TrackBugfixAction() {
-        super("Track Bugfix");
+        super("Track Bugfix", BranchType.Bugfix);
     }
 
     TrackBugfixAction(GitRepository repo) {
-        super(repo, "Track Bugfix");
+        super(repo, "Track Bugfix", BranchType.Bugfix);
     }
 
     @Override

--- a/src/main/java/gitflow/actions/TrackFeatureAction.java
+++ b/src/main/java/gitflow/actions/TrackFeatureAction.java
@@ -14,14 +14,14 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-public class TrackFeatureAction extends GitflowAction {
+public class TrackFeatureAction extends AbstractTrackAction {
 
     TrackFeatureAction(){
-        super("Track Feature");
+        super("Track Feature", BranchType.Feature);
     }
 
     TrackFeatureAction(GitRepository repo){
-        super(repo,"Track Feature");
+        super(repo,"Track Feature", BranchType.Feature);
     }
 
     @Override

--- a/src/main/java/gitflow/actions/TrackReleaseAction.java
+++ b/src/main/java/gitflow/actions/TrackReleaseAction.java
@@ -13,14 +13,14 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-public class TrackReleaseAction extends GitflowAction {
+public class TrackReleaseAction extends AbstractTrackAction {
 
     TrackReleaseAction(){
-        super("Track Release");
+        super("Track Release", BranchType.Release);
     }
 
     TrackReleaseAction(GitRepository repo){
-        super(repo,"Track Release");
+        super(repo,"Track Release", BranchType.Release);
     }
 
     @Override


### PR DESCRIPTION
As also stated in https://github.com/OpherV/gitflow4idea/issues/195 I noticed that the plugin had some performance issues, especially in larger multi-repository projects where all repositories make use of gitflow.

I made a number of improvements (at least I think they're improvements, but you'll have to agree of course):
1. Caching the already-retrieved branches. Since the plugin updates the `GitflowBranchUtil` on every git-change anyway, these don't change anyway, so caching them locally saves some time
2. Caching the prefixes found using the `GitflowConfigUtil` when figuring out if gitflow is even used in the project. This turned out to save a lot of time, as parsing the config-file apparently takes relatively long
3. Creating the actual actions only once and have the actions themselves figure out if they need to be shown or not.

When you get to merging this I'll probably have to look into https://github.com/OpherV/gitflow4idea/pull/214 again as well, since the menu-options also make use of the `RepoActions`-class and determining whether or not to show the "Advanced"-options should probably be handled differently. Or the other way around of course, depending on which you want to merge first.
Let me know what you think! :-)