### PR TITLE
Fix #221 - Support for IntelliJ 2019.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,8 @@ plugins {
 group 'gitflow4idea'
 version '0.6.7'
 
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 group 'gitflow4idea'
 version '0.6.7'
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@ plugins {
     id 'org.jetbrains.intellij' version '0.4.7'
 }
 
+compileJava {
+    options.compilerArgs += ["-Xlint"]
+}
+
 group 'gitflow4idea'
 version '0.6.7'
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 intellij {
-    version '2018.3'
+    version '2018.3.6'
     plugins 'git4idea', 'tasks'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ patchPluginXml {
     pluginDescription 'Git Flow Integration'
     version '0.6.7'
     sinceBuild '182.0'
-    untilBuild '183.*'
+    untilBuild '191.*'
     changeNotes """
       <H2>Changelog for 0.6.7</H2>         
       <ul>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.3.12'
+    id 'org.jetbrains.intellij' version '0.4.7'
 }
 
 group 'gitflow4idea'
@@ -17,7 +17,7 @@ dependencies {
 }
 
 intellij {
-    version '2018.3.6'
+    version '2019.1'
     plugins 'git4idea', 'tasks'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates the Gradle configuration to add support for IntelliJ 2019.1 (Fixes #221).