### PR TITLE
298-fix-future-deprecation plain solution

### DIFF
--- a/src/main/java/gitflow/ui/GitflowTaskDialogPanelProvider.java
+++ b/src/main/java/gitflow/ui/GitflowTaskDialogPanelProvider.java
@@ -1,10 +1,9 @@
 package gitflow.ui;
 import com.intellij.openapi.project.Project;
 import com.intellij.tasks.LocalTask;
-import com.intellij.tasks.Task;
 import com.intellij.tasks.TaskManager;
+import com.intellij.tasks.actions.vcs.VcsTaskDialogPanelProvider;
 import com.intellij.tasks.ui.TaskDialogPanel;
-import com.intellij.tasks.ui.TaskDialogPanelProvider;
 import git4idea.branch.GitBranchUtil;
 import git4idea.repo.GitRepository;
 import gitflow.GitflowBranchUtil;
@@ -13,26 +12,15 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 
-public class GitflowTaskDialogPanelProvider extends TaskDialogPanelProvider {
-
-    @Deprecated
-    @Nullable
-    @Override
-    public TaskDialogPanel getOpenTaskPanel(@NotNull Project project, @NotNull Task task) {
-        return null;
-    }
-
+public class GitflowTaskDialogPanelProvider extends VcsTaskDialogPanelProvider {
     @Nullable
     @Override
     public TaskDialogPanel getOpenTaskPanel(@NotNull Project project, @NotNull LocalTask task) {
         GitRepository currentRepo = GitBranchUtil.getCurrentRepository(project);
         GitflowBranchUtil branchUtil = GitflowBranchUtilManager.getBranchUtil(currentRepo);
-        if (branchUtil.hasGitflow()) {
-            return TaskManager.getManager(project).isVcsEnabled() ? new GitflowOpenTaskPanel(project, task, currentRepo) : null;
-        }
-        else{
-            return null;
-        }
+        return branchUtil != null && branchUtil.hasGitflow() && TaskManager.getManager(project).isVcsEnabled()
+                ? new GitflowOpenTaskPanel(project, task, currentRepo)
+                : null;
     }
 
     @Nullable
@@ -40,13 +28,9 @@ public class GitflowTaskDialogPanelProvider extends TaskDialogPanelProvider {
     public TaskDialogPanel getCloseTaskPanel(@NotNull Project project, @NotNull LocalTask task) {
         GitRepository currentRepo = GitBranchUtil.getCurrentRepository(project);
         GitflowBranchUtil branchUtil = GitflowBranchUtilManager.getBranchUtil(currentRepo);
-
-        if (branchUtil.hasGitflow()) {
-            return TaskManager.getManager(project).isVcsEnabled() ? new GitflowCloseTaskPanel(project, task, currentRepo) : null;
-        }
-        else{
-            return null;
-        }
+        return branchUtil != null && branchUtil.hasGitflow() && TaskManager.getManager(project).isVcsEnabled()
+                ? new GitflowCloseTaskPanel(project, task, currentRepo)
+                : null;
     }
 
 }


### PR DESCRIPTION
Plain solution for this issue.
`GitflowTaskDialogPanelProvider` now `extends VcsTaskDialogPanelProvider` instead of `TaskDialogPanelProvider`, not having to implement `abstract TaskDialogPanel getOpenTaskPanel(@NotNull Project, @NotNull Task)`, because concrete method of `VcsTaskDialogPanelProvider` will be dropped at once with the abstract one -- us not having to cope with that.