### PR TITLE
#314 Replace AllIcons.Vcs.CheckOut to AllIcons.Actions.CheckOut

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,7 +39,7 @@
         />
         <action id="Gitflow.TrackFeature" class="gitflow.actions.TrackFeatureAction"
                 text="Track Feature..."
-                icon="AllIcons.Vcs.CheckOut"
+                icon="AllIcons.Actions.CheckOut"
         />
 
         <action id="Gitflow.StartRelease" class="gitflow.actions.StartReleaseAction"


### PR DESCRIPTION
Fixes #314 

Tested with PyCharm 2020.3

* After restart there is no more exceptions about missing icon