### PR TITLE
Add support for modern GitFlowNext (Tower) version strings

### DIFF
--- a/GITFLOW_VERSION.md
+++ b/GITFLOW_VERSION.md
@@ -1,16 +1,22 @@
-The plugin requires that you have gitflow installed, specifically the [AVH edition](https://github.com/petervanderdoes/gitflow). This is because the [Vanilla Git Flow](https://github.com/nvie/gitflow) hasn't been maintained in years
+The plugin requires that you have a maintained fork of gitflow installed. We recommend the modern **[GitFlowNext (by Tower)](https://github.com/git-tower/git-flow)** or the legacy **[AVH edition](https://github.com/petervanderdoes/gitflow)**. This is because the [Vanilla Git Flow](https://github.com/nvie/gitflow) hasn't been maintained in years.
+
+> **Note for Windows Users:** Git for Windows removed the built-in AVH edition starting from version 2.51.1. If you are getting a "command not found" error, you must install a modern alternative like GitFlowNext.
 
 **How to check Git Flow version**
 
 run `git flow version` 
 
-If it says `0.4.1` then you have the wrong version. You will have to uninstall it and then refer to [AVH edition](https://github.com/petervanderdoes/gitflow) docs for installation. 
+If it says `0.4.1`, then you have the wrong (Vanilla) version. You will have to uninstall it and then install a supported fork. 
+If the output contains `AVH` or `next` / `Tower`, you are good to go!
 
+**How to install GitFlowNext (Recommended)**
+
+* **Windows:** You can install it via winget: `winget install GitTower.GitFlowNext` *(Make sure to rename the downloaded executable to `git-flow.exe` and place it in your Git `mingw64\libexec\git-core` directory).*
+* **Mac/Linux/Windows:** Refer to the official [GitFlowNext Installation Docs](https://github.com/git-tower/git-flow) for detailed instructions.
 
 **How to uninstall wrong version on OSX**
 
-If installed via `brew` then run `brew uninstall git-flow`                                            
-
+If installed via `brew` then run `brew uninstall git-flow`                                      
 
 **Mac/Linux users:**
 

--- a/src/main/java/gitflow/GitflowVersionTester.java
+++ b/src/main/java/gitflow/GitflowVersionTester.java
@@ -51,13 +51,21 @@ public class GitflowVersionTester {
 
 	/**
 	 * Returns true if the {@code git flow} version can be determined
-	 * and is any AVH version ({@code #contains("AVH")}) and
+	 * and is any AVH version ({@code #contains("AVH")}), any Tower version ({@code #contains("Tower")}) ,
+	 * any Next version ({@code #contains("Next")}) and
 	 * not the unmaintained NVIE version.
 	 *
 	 * @return true if we think the git flow version is an AVH version.
 	 */
 	public boolean isSupportedVersion() {
-		return version != null && version.contains("AVH");
+		if (version == null) {
+            return false;
+        }
+        
+        String versionLower = version.toLowerCase();
+        return versionLower.contains("avh") || 
+               versionLower.contains("tower") || 
+               versionLower.contains("next");
 	}
 
 	public void init(){


### PR DESCRIPTION
The Problem:
Since Git for Windows v2.51.1, the AVH edition of git-flow is no longer included in the installer because the original repository has been unmaintained for years. When users install the modern, actively maintained alternative—GitFlowNext (maintained by Tower)—the plugin fails to initialize and throws a Could not determine git flow version exception. This happens because the plugin strictly required the AVH string in the command output.

The Solution:
This PR updates the version validation logic to accept the modern Tower version strings while continuing to reject the unmaintained Vanilla (0.4.1) version. It also updates the documentation to help users (especially on Windows) avoid installation headaches.

Changes Made:

GitflowVersionTester.java: Modified the isSupportedVersion() method. It now converts the version string to lowercase and checks if it contains avh, tower, or next.

README.md:

Added a specific note for Windows users explaining why they might be seeing "command not found" errors on modern Git installations.

Added GitFlowNext as the recommended installation method, including a Winget command for Windows.

Clarified the version checking instructions to reflect the new supported strings.

Testing:

Verified the plugin successfully initializes without errors in the IntelliJ Sandbox environment while having GitFlowNext installed on the host system.